### PR TITLE
Convert group-11803532/adi to GitHub Actions

### DIFF
--- a/.github/workflows/adi.yml
+++ b/.github/workflows/adi.yml
@@ -1,0 +1,34 @@
+name: group-11803532/adi
+on:
+  push:
+  workflow_dispatch:
+concurrency:
+  group: "${{ github.ref }}"
+  cancel-in-progress: true
+env:
+  RELEASE_TOKEN: glpat-8yCXWJCxr8HsZZMJiAQP
+jobs:
+  build_maven_project:
+    runs-on:
+      - self-hosted
+      - tag-1
+    container:
+      image: maven:3.9.8-eclipse-temurin-17
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v4.1.0
+      with:
+        fetch-depth: 20
+        lfs: true
+    - uses: actions/cache@v3.3.2
+      with:
+        path: |-
+          target/
+          .m2/repository
+        key: "${{ github.job }}"
+    - run: mvn -B package --file pom.xml
+    - uses: actions/upload-artifact@v4.1.0
+      if: success()
+      with:
+        name: "${{ github.job }}"
+        path: target/*.jar


### PR DESCRIPTION
Pipeline migrated from [GitLab](https://gitlab.com/group-11803532/adi) :tada:

## Manual steps

Perform the following steps to complete the migration:

### group-11803532/adi
- [ ] Ensure a runner with the following labels exists: tag-1